### PR TITLE
Move plorth-types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plorth-parser",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Parser for Plorth programming language",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
   },
   "author": "Rauli Laine <rauli.laine@iki.fi>",
   "license": "BSD-2-Clause",
+  "dependencies": {
+    "plorth-types": "^1.0.1"
+  },
   "devDependencies": {
     "coveralls": "^3.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.5.0",
-    "plorth-types": "^1.0.1",
     "should": "^12.0.0",
     "source-map-support": "^0.5.0",
     "typescript": "^2.5.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plorth-parser",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Parser for Plorth programming language",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This package relies on plorth-types more than just during the transpilation process, so it should be included in dependencies instead of development dependencies.